### PR TITLE
[figma]:update to 1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tant/icons",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Icon automation workflow with Figma",
   "main": "dist/tant-icons.cjs.js",
   "module": "dist/tant-icons.esm.js",


### PR DESCRIPTION
rollback event-sm size to 16x16