### PR TITLE
[figma]:update to 1.22.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tant/icons",
-  "version": "1.22.27",
+  "version": "1.22.28",
   "description": "Icon automation workflow with Figma",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",


### PR DESCRIPTION
fix logo-python-cl icon